### PR TITLE
Make Jslt2 thread-safe

### DIFF
--- a/src/main/java/jslt2/Jslt2.java
+++ b/src/main/java/jslt2/Jslt2.java
@@ -126,9 +126,7 @@ public class Jslt2 {
     
     private ResourceResolver resolver;
     
-    private Compiler compiler;
-    private VM vm;
-    
+    private Compiler compiler;        
     private Map<String, Jslt2Function> userFunctions;
     
     /**
@@ -150,9 +148,7 @@ public class Jslt2 {
         this.minStackSize = minStackSize;
         this.maxStackSize = maxStackSize;
         
-        this.vm = new VM(this);
-        this.compiler = new Compiler(this);
-        
+        this.compiler = new Compiler(this);        
         this.userFunctions = new HashMap<>();
         
         new Jslt2StdLibrary(this);
@@ -268,8 +264,8 @@ public class Jslt2 {
         if(this.isDebugMode) {
             System.out.println(bytecode.dump());
         }
-        
-        JsonNode result = this.vm.execute(bytecode, input);
+                
+        JsonNode result = new VM(this).execute(bytecode, input);
         if(!this.includeNulls) {
             result = Jslt2Util.removeNullNodes(result);
         }
@@ -318,7 +314,7 @@ public class Jslt2 {
         Parser parser = new Parser(scanner);
         
         Bytecode code = this.compiler.compile(parser.parseProgram());
-        return new Template(this, code);
+        return new Template(new VM(this), code);
     }
     
     /**

--- a/src/main/java/jslt2/Template.java
+++ b/src/main/java/jslt2/Template.java
@@ -6,6 +6,7 @@ package jslt2;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import jslt2.vm.Bytecode;
+import jslt2.vm.VM;
 
 /**
  * @author Tony
@@ -13,15 +14,15 @@ import jslt2.vm.Bytecode;
  */
 public class Template {
 
-    private Jslt2 runtime;
+    private VM vm;
     private Bytecode bytecode;
     
     /**
      * @param runtime
      * @param bytecode
      */
-    public Template(Jslt2 runtime, Bytecode bytecode) {
-        this.runtime = runtime;
+    public Template(VM vm, Bytecode bytecode) {
+        this.vm = vm;
         this.bytecode = bytecode;
     }
     
@@ -32,7 +33,7 @@ public class Template {
      * @return the {@link JsonNode} result
      */
     public JsonNode eval(JsonNode input) {
-        return this.runtime.eval(this.bytecode, input);
+        return this.vm.execute(this.bytecode, input);
     }
 
 }


### PR DESCRIPTION
Makes the Jslt2 runtime eval and compile functions thread-safe.  `Template`'s should be assigned to a thread (these are not thread-safe)